### PR TITLE
DATAHUB-1051: Expire concurrent connections cache after 1 month of no activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Kong plugin to make sure user can have a limited number of total and concurrent connections.
 
+## Concurrent vs. Per-unit rate limits
+
+"Concurrent" connections is a misnomer in this plugin, because it's actually only affecting the number of websocket connections. This was implemented purposefully to handle APIs that support both websockets and standard HTTP connections. We needed a way to differentiate between the two and restrict them independently.
+
+**TODO**: Implement a separate websocket configuration for limiting active websocket connections and use "concurrent" as a limit of the total number of connections.
+
+## Cache Expiration
+
+When incrementing or decrementing the number of concurrent connections in the Redis cache, we use an expiration of 1 month for the value. This is because it's possible for websocket connections to run for several days, or even weeks, before they are refreshed with a new connection. We don't want the value to be lost in the meantime.
+
 ## Testing
 
 To run lint and tests install

--- a/kong/plugins/connections-quota/handler.lua
+++ b/kong/plugins/connections-quota/handler.lua
@@ -317,7 +317,7 @@ function ConnectionsQuotaHandler:log(conf)
     local service_group = kong.ctx.plugin.service_group
     local ok, err = timer_at(0, decrement, conf, identifier, service_group, 1)
     if not ok then
-      kong.log.err("failed to create decrement timer: ", err)
+      kong.log.err("failed to decrement counter after ws closed: ", err)
     end
   end
 end

--- a/kong/plugins/connections-quota/policies/strategy/redis.lua
+++ b/kong/plugins/connections-quota/policies/strategy/redis.lua
@@ -7,7 +7,6 @@ local EXPIRATIONS = require "kong.plugins.connections-quota.expiration"
 
 local strategy = function (get_local_key, CONCURRENT_CONNECTIONS_QUOTA, TOTAL_CONNECTIONS_QUOTA)
 
-  local EXPIRATION = 10*60
   local sock_opts = {}
 
   local function is_present(str)
@@ -76,7 +75,7 @@ local strategy = function (get_local_key, CONCURRENT_CONNECTIONS_QUOTA, TOTAL_CO
 
     red:init_pipeline()
     red:incrby(cache_key, value)
-    red:expire(cache_key, EXPIRATION)
+    red:expire(cache_key, EXPIRATIONS["month"])
 
     local _, err = red:commit_pipeline()
     if err then
@@ -213,7 +212,7 @@ local strategy = function (get_local_key, CONCURRENT_CONNECTIONS_QUOTA, TOTAL_CO
 
       red:init_pipeline()
       red:decrby(cache_key, value)
-      red:expire(cache_key, EXPIRATION)
+      red:expire(cache_key, EXPIRATIONS["month"])
 
       local _, err = red:commit_pipeline()
       if err then


### PR DESCRIPTION
When a websocket connection is created or deleted, the cache key is updated with an expiration of 10 minutes. This causes lots of issues, because websockets connections very often last longer than 10 minutes.

This uses a 1 month expiration for this cache key. Ideally, we don't expire this cache at all. However, that would lead to an ever-growing number of keys. 1 month is pretty sane, because most folks will either create a new connection or terminate an existing connection within a 1 month period.